### PR TITLE
Allow service body administrators to edit users they own.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ For instructions on installing the root server, see [the page on installing a ne
 CHANGELIST
 ----------
 
-***Version 2.10.8* ** *- TBD*
+***Version 2.11.0* ** *- TBD*
 
 - There was an exceedingly rare bug in the history display. If a user had been changed for a Service body, and the previous user had been deleted, it would hang the history display.
 - Added support for disabling the forced port in the include URIs. Some VM servers misrepresent the ports when forcing SSL.
 - Improved code commenting.
 - Fixed an inconsistency in time format of defaults for duration time
+- Added the ability to allow Service Body Administrators to edit their users.
 
 ***Version 2.10.7* ** *- July 27, 2018*
 

--- a/main_server/client_interface/serverInfo.xml
+++ b/main_server/client_interface/serverInfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <bmltInfo>
 	<serverVersion>
-		<readableString>2.10.8</readableString>
+		<readableString>2.11.0</readableString>
 	</serverVersion>
 </bmltInfo>

--- a/main_server/local_server/db_connect.php
+++ b/main_server/local_server/db_connect.php
@@ -109,5 +109,18 @@ function DB_Connect_and_Upgrade ( )
 		// We don't die if the thing already exists. We just mosey on along as if nothing happened.
 		}
 
-	// Schema migrations go here
+	try
+		{
+		// TODO fix version number in below comment
+		// Version x.x.x added 1 column to the users table for user ownership.
+		$table = "$dbPrefix"."_comdef_users";
+		$alter_sql = "ALTER TABLE `$table` ADD `owner_id_bigint` BIGINT NOT NULL DEFAULT -1 AFTER `lang_enum`";
+		c_comdef_dbsingleton::preparedExec($alter_sql);
+		$alter_sql = "CREATE INDEX owner_id_bigint ON $table (owner_id_bigint)";
+		c_comdef_dbsingleton::preparedExec($alter_sql);
+		}
+	catch ( Exception $e )
+		{
+		// We don't die if the thing already exists. We just mosey on along as if nothing happened.
+		}
 }?>

--- a/main_server/local_server/db_connect.php
+++ b/main_server/local_server/db_connect.php
@@ -108,4 +108,6 @@ function DB_Connect_and_Upgrade ( )
 		{
 		// We don't die if the thing already exists. We just mosey on along as if nothing happened.
 		}
+
+	// Schema migrations go here
 }?>

--- a/main_server/local_server/install_wizard/installer_ajax.php
+++ b/main_server/local_server/install_wizard/installer_ajax.php
@@ -57,9 +57,10 @@ if (    isset ( $http_vars['ajax_req'] )        && ($http_vars['ajax_req'] == 'i
     &&  isset ( $http_vars['admin_password'] )  && $http_vars['admin_password']  // This is cleartext, but that can't be helped. This is the only place in the installer where this happens.
      )
     {
+    // Put new initial schema stuff here
     $value_array = array();
     $db_prefix = ($http_vars['dbType'] != 'mysql') ? $http_vars['dbName'].'.' : '';
-            
+
     $sql[] = str_replace ( '%%PREFIX%%', preg_replace ( '|[^a-z_\.\-A-Z0-9]|', '', $db_prefix.$http_vars['dbPrefix'] ), file_get_contents ( dirname ( __FILE__ ).'/sql_files/initialMeetingsStructure.sql' ) );
     $sql[] = str_replace ( '%%PREFIX%%', preg_replace ( '|[^a-z_\.\-A-Z0-9]|', '', $db_prefix.$http_vars['dbPrefix'] ), file_get_contents ( dirname ( __FILE__ ).'/sql_files/initialFormatsStructure.sql' ) );
     $sql[] = str_replace ( '%%PREFIX%%', preg_replace ( '|[^a-z_\.\-A-Z0-9]|', '', $db_prefix.$http_vars['dbPrefix'] ), file_get_contents ( dirname ( __FILE__ ).'/sql_files/initialChangesStructure.sql' ) );

--- a/main_server/local_server/install_wizard/installer_ajax.php
+++ b/main_server/local_server/install_wizard/installer_ajax.php
@@ -57,7 +57,6 @@ if (    isset ( $http_vars['ajax_req'] )        && ($http_vars['ajax_req'] == 'i
     &&  isset ( $http_vars['admin_password'] )  && $http_vars['admin_password']  // This is cleartext, but that can't be helped. This is the only place in the installer where this happens.
      )
     {
-    // Put new initial schema stuff here
     $value_array = array();
     $db_prefix = ($http_vars['dbType'] != 'mysql') ? $http_vars['dbName'].'.' : '';
 

--- a/main_server/local_server/install_wizard/sql_files/InitialUsersStructure.sql
+++ b/main_server/local_server/install_wizard/sql_files/InitialUsersStructure.sql
@@ -8,10 +8,12 @@ CREATE TABLE `%%PREFIX%%_comdef_users` (
   `password_string` varchar(255) NOT NULL,
   `last_access_datetime` datetime NOT NULL default '1970-01-01 00:00:00',
   `lang_enum` varchar(7) NOT NULL default 'en',
+  `owner_id_bigint` BIGINT(20) NOT NULL default -1,
   PRIMARY KEY  (`id_bigint`),
   UNIQUE KEY `login_string` (`login_string`),
   KEY `user_level_tinyint` (`user_level_tinyint`),
   KEY `email_address_string` (`email_address_string`),
   KEY `last_access_datetime` (`last_access_datetime`),
-  KEY `lang_enum` (`lang_enum`)
+  KEY `lang_enum` (`lang_enum`),
+  KEY `owner_id_bigint` (`owner_id_bigint`)
 ) DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;

--- a/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -383,6 +383,7 @@ class c_comdef_admin_ajax_handler
     function HandleUserCreate ( $in_user_data   ///< A JSON object, containing the new User data.
                                 )
     {
+        // This is where users are created
         if ( c_comdef_server::IsUserServerAdmin(null,true) )
             {
             $json_tool = new PhpJsonXmlArrayStringInterchanger;
@@ -458,6 +459,7 @@ class c_comdef_admin_ajax_handler
     function HandleUserChange ( $in_user_data   ///< A JSON object, containing the new User data.
                                 )
     {
+        // This is where users are updated
         if ( c_comdef_server::IsUserServerAdmin(null,true) )
             {
             $json_tool = new PhpJsonXmlArrayStringInterchanger;

--- a/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -400,7 +400,7 @@ class c_comdef_admin_ajax_handler
                 $password = trim ( $the_new_user[6] );
                 $user_owner = intval ( $the_new_user[7] );
 
-                $user_owner_user = c_comdef_server::GetUserByIDObj( $user_owner );
+                $user_owner_user = $this->my_server->GetUserByIDObj( $user_owner );
                 if ( is_null($user_owner_user) || $user_owner_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN )
                     {
                     $user_owner = -1;
@@ -485,7 +485,7 @@ class c_comdef_admin_ajax_handler
                 $user_owner = intval ( $the_changed_user[7] );
                 $user_to_change = $this->my_server->GetUserByIDObj ( $id );
 
-                $user_owner_user = c_comdef_server::GetUserByIDObj( $user_owner );
+                $user_owner_user = $this->my_server->GetUserByIDObj( $user_owner );
                 if ( is_null($user_owner_user) || $user_owner_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN )
                     {
                     $user_owner = -1;

--- a/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -398,10 +398,17 @@ class c_comdef_admin_ajax_handler
                 $email = $the_new_user[4];
                 $user_level = intval ( $the_new_user[5] );
                 $password = trim ( $the_new_user[6] );
-            
+                $user_owner = intval ( $the_new_user[7] );
+
+                $user_owner_user = c_comdef_server::GetUserByIDObj( $user_owner );
+                if ( is_null($user_owner_user) || $user_owner_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN )
+                    {
+                    $user_owner = -1;
+                    }
+
                 if ( !$this->my_server->GetUserByLogin ( $login ) )
                     {
-                    $user_to_create = new c_comdef_user ( NULL, 0, $user_level, $email, $login, "", $this->my_server->GetLocalLang(), $name, $description, -1, NULL);
+                    $user_to_create = new c_comdef_user ( NULL, 0, $user_level, $email, $login, "", $this->my_server->GetLocalLang(), $name, $description, $user_owner, NULL);
             
                     if ( $user_to_create instanceof c_comdef_user )
                         {
@@ -475,7 +482,14 @@ class c_comdef_admin_ajax_handler
                 $email = $the_changed_user[4];
                 $user_level = intval ( $the_changed_user[5] );
                 $password = trim ( $the_changed_user[6] );
+                $user_owner = intval ( $the_changed_user[7] );
                 $user_to_change = $this->my_server->GetUserByIDObj ( $id );
+
+                $user_owner_user = c_comdef_server::GetUserByIDObj( $user_owner );
+                if ( is_null($user_owner_user) || $user_owner_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN )
+                    {
+                    $user_owner = -1;
+                    }
 
                 if ( $user_to_change instanceof c_comdef_user )
                     {
@@ -490,10 +504,11 @@ class c_comdef_admin_ajax_handler
                     $user_to_change->SetLocalName ( $name );
                     $user_to_change->SetLocalDescription ( $description );
                     $user_to_change->SetEmailAddress ( $email );
-                    // Only allow server admins to set user level
+                    // Only allow server admins to set user level and user owner
                     if ( $isServerAdmin )
                         {
                         $user_to_change->SetUserLevel ( $user_level );
+                        $user_to_change->SetOwnerID( $user_owner );
                         }
                     
                     if ( $password )

--- a/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -508,7 +508,7 @@ class c_comdef_admin_ajax_handler
                     if ( $isServerAdmin )
                         {
                         $user_to_change->SetUserLevel ( $user_level );
-                        $user_to_change->SetOwnerID( $user_owner );
+                        $user_to_change->SetOwnerID ( $user_owner );
                         }
                     
                     if ( $password )

--- a/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -383,7 +383,6 @@ class c_comdef_admin_ajax_handler
     function HandleUserCreate ( $in_user_data   ///< A JSON object, containing the new User data.
                                 )
     {
-        // This is where users are created
         if ( c_comdef_server::IsUserServerAdmin(null,true) )
             {
             $json_tool = new PhpJsonXmlArrayStringInterchanger;

--- a/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -573,6 +573,7 @@ class c_comdef_admin_ajax_handler
                     {
                     if ( $user_to_delete->DeleteFromDB() )
                         {
+                        $user_to_delete->ResetChildUsers();
                         if ( $in_delete_permanently )
                             {
                             $this->DeleteUserChanges ( $in_user_id );

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -163,6 +163,7 @@ class c_comdef_admin_main_console
             $ret .= '<script type="text/javascript">';
                 $ret .= 'var g_ajax_callback_uri = \''.self::js_html ( $this->my_ajax_uri ).'\';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
                 $ret .= 'var g_current_user_id = \''.self::js_html ( $this->my_user->GetID() ).'\';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
+                $ret .= 'var g_is_server_admin = '. ($this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN ? 'true' : 'false' ) . ';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
                 $ret .= 'var g_formats_array = '.array2json ( $this->my_formats ).';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
                 $ret .= 'var g_langs = ["'.implode ( '","', $this->my_lang_ids ).'"];'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
                 $ret .= 'var g_lang_names = '.array2json ( $this->my_server->GetServerLangs() ).';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
@@ -712,10 +713,12 @@ class c_comdef_admin_main_console
                 $ret .= '<span id="bmlt_admin_user_save_ajax_button_throbber_span" class="bmlt_admin_ajax_button_throbber_span item_hidden"><img src="local_server/server_admin/style/images/ajax-throbber-white.gif" alt="AJAX Throbber" /></span>';
             $ret .= '</span>';
             $ret .= '<span class="bmlt_admin_meeting_editor_form_middle_button_single_span bmlt_admin_delete_button_span hide_in_new_user_admin">';
-                $ret .= '<a id="bmlt_admin_meeting_editor_form_user_delete_button" href="javascript:admin_handler_object.deleteUser();" class="bmlt_admin_ajax_button button">'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['user_delete_button'] ).'</a>';
+                $delete_button_href = $this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN ? 'javascript:admin_handler_object.deleteUser();' : 'javascript:void(0);';
+                $ret .= '<a id="bmlt_admin_meeting_editor_form_user_delete_button" href="'.$delete_button_href.'" class="bmlt_admin_ajax_button button">'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['user_delete_button'] ).'</a>';
                 $ret .= '<span id="bmlt_admin_user_delete_ajax_button_throbber_span" class="bmlt_admin_ajax_button_throbber_span item_hidden"><img src="local_server/server_admin/style/images/ajax-throbber-white.gif" alt="AJAX Throbber" /></span>';
                 $ret .= '<span class="perm_checkbox_span">';
-                    $ret .= '<input type="checkbox" id="bmlt_admin_user_delete_perm_checkbox" />';
+                    $delete_perm_checkbox_disabled = $this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN ? '' : 'disabled ';
+                    $ret .= '<input type="checkbox" id="bmlt_admin_user_delete_perm_checkbox" '.$delete_perm_checkbox_disabled.'/>';
                     $ret .= '<label for="bmlt_admin_user_delete_perm_checkbox">'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['user_delete_perm_checkbox'] ).'</label>';
                 $ret .= '</span>';
             $ret .= '</span>';

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -163,7 +163,7 @@ class c_comdef_admin_main_console
             $ret .= '<script type="text/javascript">';
                 $ret .= 'var g_ajax_callback_uri = \''.self::js_html ( $this->my_ajax_uri ).'\';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
                 $ret .= 'var g_current_user_id = \''.self::js_html ( $this->my_user->GetID() ).'\';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
-                $ret .= 'var g_is_server_admin = '. ($this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN ? 'true' : 'false' ) . ';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
+                $ret .= 'var g_is_server_admin = '. ($this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN ? 'true' : 'false' ).';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
                 $ret .= 'var g_formats_array = '.array2json ( $this->my_formats ).';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
                 $ret .= 'var g_langs = ["'.implode ( '","', $this->my_lang_ids ).'"];'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
                 $ret .= 'var g_lang_names = '.array2json ( $this->my_server->GetServerLangs() ).';'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -518,6 +518,7 @@ class c_comdef_admin_main_console
     ************************************************************************************************************/
     function return_user_admin_panel()
     {
+        // Generates DOM for user editing
         $ret = 'NOT AUTHORIZED TO EDIT USERS';
         
         if ( $this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN )

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -690,7 +690,8 @@ class c_comdef_admin_main_console
     ************************************************************************************************************/
     function create_user_level_popup ()
     {
-        $ret = '<select id="bmlt_admin_single_user_editor_level_select" class="bmlt_admin_single_user_editor_level_select" onchange="admin_handler_object.readUserEditorState();">';
+        $disabled = $this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN ? '' : ' disabled';
+        $ret = '<select id="bmlt_admin_single_user_editor_level_select" class="bmlt_admin_single_user_editor_level_select" onchange="admin_handler_object.readUserEditorState();"'.$disabled.'>';
             $first = true;
             $ret .= '<option value="2">'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['user_editor_account_type_2'] ).'</option>';
             $ret .= '<option value="5">'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['user_editor_account_type_5'] ).'</option>';

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -229,7 +229,8 @@ class c_comdef_admin_main_console
    /* Description:3 */  $ret .= '\''.self::js_html ( $user->GetLocalDescription() ).'\',';
          /* eMail:4 */  $ret .= '\''.self::js_html ( ( ($this->my_user->GetUserLevel() == _USER_LEVEL_SERVICE_BODY_ADMIN) || ($this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN) || ($user->GetID() == $this->my_user->GetID()) ) ? $user->GetEmailAddress() : '' ).'\',';
     /* User Level:5 */  $ret .= $user->GetUserLevel().',';
-     /*  Password:6 */  $ret .= '\'\''; // We do not give a password, but one can be sent in to change the current one, so we have a placeholder.
+      /* Password:6 */  $ret .= '\'\','; // We do not give a password, but one can be sent in to change the current one, so we have a placeholder.
+    /* User Owner:7 */  $ret .= self::js_html ( $user->GetOwnerID() );
                     $ret .=']';
                     if ( $c < (count ( $this->my_users ) - 1) )
                         {
@@ -616,6 +617,13 @@ class c_comdef_admin_main_console
                     $ret .= '<div class="clear_both"></div>';
                 $ret .= '</div>';
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
+                    $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['user_editor_user_owner_label'] ).'</span>';
+                    $ret .= '<span class="bmlt_admin_value_left" id="user_editor_single_non_service_body_admin_display">';
+                        $ret .= $this->create_user_owner_popup( $this->my_users );
+                    $ret .= '</span>';
+                    $ret .= '<div class="clear_both"></div>';
+                $ret .= '</div>';
+                $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['user_editor_account_login_label'] ).'</span>';
                     $ret .= '<span class="bmlt_admin_value_left"><input name="bmlt_admin_user_editor_login_input" id="bmlt_admin_user_editor_login_input" type="text" value="" onkeyup="admin_handler_object.handleTextInputChange(this);admin_handler_object.readUserEditorState();" onchange="admin_handler_object.handleTextInputChange(this);admin_handler_object.readUserEditorState();" onfocus="admin_handler_object.handleTextInputFocus(this);" onblur="admin_handler_object.handleTextInputBlur(this);" /></span>';
                     $ret .= '<script type="text/javascript">admin_handler_object.handleTextInputLoad(document.getElementById(\'bmlt_admin_user_editor_login_input\'),\''.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['user_editor_login_default_text'] ).'\', true);</script>';
@@ -701,7 +709,28 @@ class c_comdef_admin_main_console
         
         return $ret;
     }
-    
+
+    /********************************************************************************************************//**
+    \brief This creates the HTML for a user owner selection popup menu.
+    \returns The HTML and JavaScript for the popup menu (select element).
+     ************************************************************************************************************/
+    function create_user_owner_popup ($users)
+    {
+        $disabled = $this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN ? '' : ' disabled';
+        $ret = '<select id="bmlt_admin_single_user_editor_user_owner_select" class="bmlt_admin_single_user_editor_user_select" onchange="admin_handler_object.readUserEditorState();"'.$disabled.'>';
+        sort($users);
+        for ( $index = 0; $index  < count ( $users ); $index++ )
+            {
+            $user = $users[$index];
+            $ret .= '<option value="'.$user->GetID().'"';
+            $ret .= '>'.htmlspecialchars ( $user->GetLocalName() ).'</option>'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
+            }
+
+        $ret .= '</select>'.(defined ( '__DEBUG_MODE__' ) ? "\n" : '');
+
+        return $ret;
+    }
+
     /********************************************************************************************************//**
     \brief This constructs the User editor buttons as a div.
     \returns The HTML and JavaScript for the button panel.

--- a/main_server/local_server/server_admin/lang/de/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/de/server_admin_strings.inc.php
@@ -214,6 +214,7 @@
 	                                        'user_editor_account_login_label'                       =>  'Benutzer Login:',
 											'user_editor_login_default_text'                        =>  'Trage den Benutzer Login ein',
 	                                        'user_editor_account_type_label'                        =>  'Benutzer ist ein:',
+	                                        'user_editor_user_owner_label'                          =>  'Owned By: ', // TODO translate
 	                                        'user_editor_account_type_1'                            =>  'Server Administrator',
 	                                        'user_editor_account_type_2'                            =>  'Service Body Administrator',
 	                                        'user_editor_account_type_3'                            =>  'Service Body Editor',

--- a/main_server/local_server/server_admin/lang/en/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/en/server_admin_strings.inc.php
@@ -214,6 +214,7 @@
 	                                        'user_editor_account_login_label'                       =>  'User Login:',
 											'user_editor_login_default_text'                        =>  'Enter the User Login',
 	                                        'user_editor_account_type_label'                        =>  'User Is A:',
+	                                        'user_editor_user_owner_label'                          =>  'Owned By: ',
 	                                        'user_editor_account_type_1'                            =>  'Server Administrator',
 	                                        'user_editor_account_type_2'                            =>  'Service Body Administrator',
 	                                        'user_editor_account_type_3'                            =>  'Service Body Editor',

--- a/main_server/local_server/server_admin/lang/es/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/es/server_admin_strings.inc.php
@@ -214,6 +214,7 @@
 	                                        'user_editor_account_login_label'                       =>  'Registro de usuarios:',
 											'user_editor_login_default_text'                        =>  'Introduzca el nombre de usuario',
 	                                        'user_editor_account_type_label'                        =>  'User Is A:',
+	                                        'user_editor_user_owner_label'                          =>  'Owned By: ', // TODO translate
 	                                        'user_editor_account_type_1'                            =>  'Administrador de Servicio',
 	                                        'user_editor_account_type_2'                            =>  'Administrador de cuerpo de servicior',
 	                                        'user_editor_account_type_3'                            =>  'Editor cuerpo de servicio',

--- a/main_server/local_server/server_admin/lang/es/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/es/server_admin_strings.inc.php
@@ -214,7 +214,7 @@
 	                                        'user_editor_account_login_label'                       =>  'Registro de usuarios:',
 											'user_editor_login_default_text'                        =>  'Introduzca el nombre de usuario',
 	                                        'user_editor_account_type_label'                        =>  'User Is A:',
-	                                        'user_editor_user_owner_label'                          =>  'Owned By: ', // TODO translate
+	                                        'user_editor_user_owner_label'                          =>  'Controlado Por: ',
 	                                        'user_editor_account_type_1'                            =>  'Administrador de Servicio',
 	                                        'user_editor_account_type_2'                            =>  'Administrador de cuerpo de servicior',
 	                                        'user_editor_account_type_3'                            =>  'Editor cuerpo de servicio',

--- a/main_server/local_server/server_admin/lang/fr/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/fr/server_admin_strings.inc.php
@@ -214,6 +214,7 @@
 	                                        'user_editor_account_login_label'                       =>  'Login utlisateur:',
 											'user_editor_login_default_text'                        =>  'Entrer mon login',
 	                                        'user_editor_account_type_label'                        =>  'Je suis un:',
+	                                        'user_editor_user_owner_label'                          =>  'Owned By: ', // TODO translate
 	                                        'user_editor_account_type_1'                            =>  'Administrateur du serveur',
 	                                        'user_editor_account_type_2'                            =>  'Administrateur de la composante de structure de service ',
 	                                        'user_editor_account_type_3'                            =>  'Editeur de la composante de structure de service',

--- a/main_server/local_server/server_admin/lang/it/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/it/server_admin_strings.inc.php
@@ -212,6 +212,7 @@
 	                                        'user_editor_account_login_label'                       =>  'Autenticazione dell\'utente:',//'User Login:',
 											'user_editor_login_default_text'                        =>  'Inserisci l\'autenticazione dell\'utente',//'Enter the User Login',
 	                                        'user_editor_account_type_label'                        =>  'L\'utente è un:',//'User Is A:',
+	                                        'user_editor_user_owner_label'                          =>  'Owned By: ', // TODO translate
 	                                        'user_editor_account_type_1'                            =>  'Amministratore del server',//'Server Administrator',
 	                                        'user_editor_account_type_2'                            =>  'Amministratore della struttura di servizio',//'Service Body Administrator',
 	                                        'user_editor_account_type_3'                            =>  'Editor nella struttura di servizio',//'Service Body Editor',

--- a/main_server/local_server/server_admin/lang/sv/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/sv/server_admin_strings.inc.php
@@ -215,6 +215,7 @@
 	                                        'user_editor_account_login_label'                       =>  'Användarnamn:',
 											'user_editor_login_default_text'                        =>  'Fyll i användarnamn',
 	                                        'user_editor_account_type_label'                        =>  'Användaren är en:',
+	                                        'user_editor_user_owner_label'                          =>  'Owned By: ', // TODO translate
 	                                        'user_editor_account_type_1'                            =>  'Server Administratör',
 	                                        'user_editor_account_type_2'                            =>  'Serviceenhets Administratör',
 	                                        'user_editor_account_type_3'                            =>  'Serviceenhet Redaktör',

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -4076,6 +4076,23 @@ function BMLT_Server_Admin ()
                     user_level_sa_span.className = 'bmlt_admin_value_left light_italic_display';
                     };
                 };
+
+                var user_owner_id = parseInt(selected_user_object[7]);
+                var user_owner_field = document.getElementById ( 'bmlt_admin_single_user_editor_user_owner_select' );
+                for ( var i = 0; i < user_owner_field.options.length; i++ )
+                    {
+                    var option = user_owner_field.options[i];
+                    if ( user_owner_id === -1 && parseInt(option.value) === 1 )
+                        {
+                        user_owner_field.selectedIndex = i;
+                        break;
+                        }
+                    else if ( parseInt(option.value) === user_owner_id )
+                        {
+                        user_owner_field.selectedIndex = i;
+                        break;
+                        }
+                    }
             };
         
         var perm_checkbox = document.getElementById ( 'bmlt_admin_user_delete_perm_checkbox' );
@@ -4111,7 +4128,10 @@ function BMLT_Server_Admin ()
         
         var password_field = document.getElementById ( 'bmlt_admin_user_editor_password_input' );
         main_user_editor_div.current_user_object[6] = (password_field.value && (password_field.value != password_field.defaultValue)) ? password_field.value : '';
-        
+
+        var user_owner_select = document.getElementById ( 'bmlt_admin_single_user_editor_user_owner_select' );
+        main_user_editor_div.current_user_object[7] = parseInt(user_owner_select.options[user_owner_select.selectedIndex].value, 10);
+
         this.validateUserEditorButtons();
     };
 
@@ -4483,6 +4503,7 @@ function BMLT_Server_Admin ()
         new_user_object[4] = '';
         new_user_object[5] = 4;
         new_user_object[6] = '';
+        new_user_object[7] = -1;
         
         return new_user_object;
     };

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -4506,8 +4506,16 @@ function BMLT_Server_Admin ()
             save_button.className = 'bmlt_admin_ajax_button button_disabled';
             cancel_button.className = 'bmlt_admin_ajax_button button_disabled';
             };
-        
-        delete_button.className = 'bmlt_admin_ajax_button button';
+
+        if ( g_is_server_admin )
+            {
+            delete_button.className = 'bmlt_admin_ajax_button button';
+            }
+        else
+            {
+            delete_button.className = 'bmlt_admin_ajax_button button_disabled';
+            }
+
     };
     
     // #mark - 

--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -432,6 +432,7 @@ class c_comdef_server
                                                                     $row['lang_enum'],
                                                                     $row['name_string'],
                                                                     $row['description_string'],
+                                                                    $row['owner_id_bigint'],
                                                                     $row['last_access_datetime']
                                                                     );
                 }
@@ -940,6 +941,7 @@ class c_comdef_server
         
         \returns the ID of the user. Null is it failed.
     */
+    // TODO Add an $in_owner_id_bigint parameter
     static function AddNewUser (
                                 $in_user_login,                 ///< The login for this user
                                 $in_user_unencrypted_password,  ///< The unencrypted password for this user
@@ -971,7 +973,7 @@ class c_comdef_server
         
         $encrypted_password = FullCrypt ( trim ( $in_user_unencrypted_password ) );
         
-        $user_obj = new c_comdef_user ( self::GetServer(), null, $in_user_level, $in_user_email, $in_user_login, $encrypted_password, $in_lang_enum, $in_name_string, $in_description_string );
+        $user_obj = new c_comdef_user ( self::GetServer(), null, $in_user_level, $in_user_email, $in_user_login, $encrypted_password, $in_lang_enum, $in_name_string, $in_description_string, -1 );
         
         if ( $user_obj instanceof c_comdef_user )
             {
@@ -1310,7 +1312,31 @@ class c_comdef_server
     
     return $ret;
     }
-    
+
+
+    /*******************************************************************/
+    /** \brief Find out if the user is a service body admin.
+
+    \returns a boolean. True if the user is a service body admin.
+     */
+    static function IsUserServiceBodyAdmin(  $in_user_obj = null,    ///< A reference to a c_comdef_user object instance. If null, the current user will be checked.
+                                             $in_is_ajax = false     ///< If it's an AJAX handler, we don't regenerate the session. Some browsers seem antsy about that.
+                                             )
+    {
+    $ret = false;
+
+    if ( !($in_user_obj instanceof c_comdef_user) )
+        {
+        $in_user_obj = self::GetCurrentUserObj($in_is_ajax);
+        }
+
+    if ( $in_user_obj instanceof c_comdef_user )
+        {
+        $ret = ($in_user_obj->GetUserLevel() == _USER_LEVEL_SERVICE_BODY_ADMIN);
+        }
+
+    return $ret;
+    }
     /*******************************************************************/
     /** \brief Given a login and password, looks up the user, and returns
         an encrypted password for that user.
@@ -1629,6 +1655,7 @@ class c_comdef_server
                                                 $row['lang_enum'],
                                                 $row['name_string'],
                                                 $row['description_string'],
+                                                $row['owner_id_bigint'],
                                                 $row['last_access_datetime'] );
                 }
             }

--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -941,7 +941,6 @@ class c_comdef_server
         
         \returns the ID of the user. Null is it failed.
     */
-    // TODO Add an $in_owner_id_bigint parameter
     static function AddNewUser (
                                 $in_user_login,                 ///< The login for this user
                                 $in_user_unencrypted_password,  ///< The unencrypted password for this user
@@ -949,7 +948,8 @@ class c_comdef_server
                                 $in_user_email,                 ///< The email address for this user
                                 $in_name_string = null,         ///< The user's Name (Optional)
                                 $in_description_string = null,  ///< The description of the user (Optional)
-                                $in_lang_enum = null            ///< The language for the user (Optional -If not supplied, the server default will be used)
+                                $in_lang_enum = null,           ///< The language for the user (Optional -If not supplied, the server default will be used)
+                                $in_owner_id = -1               ///< The id of the user that owns this user
                                 )
     {
         $id = null;
@@ -973,7 +973,7 @@ class c_comdef_server
         
         $encrypted_password = FullCrypt ( trim ( $in_user_unencrypted_password ) );
         
-        $user_obj = new c_comdef_user ( self::GetServer(), null, $in_user_level, $in_user_email, $in_user_login, $encrypted_password, $in_lang_enum, $in_name_string, $in_description_string, -1 );
+        $user_obj = new c_comdef_user ( self::GetServer(), null, $in_user_level, $in_user_email, $in_user_login, $encrypted_password, $in_lang_enum, $in_name_string, $in_description_string, $in_owner_id );
         
         if ( $user_obj instanceof c_comdef_user )
             {

--- a/main_server/server/classes/c_comdef_user.class.php
+++ b/main_server/server/classes/c_comdef_user.class.php
@@ -794,7 +794,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 				return true;
 				}
 
-			if (c_comdef_server::IsUserServiceBodyAdmin() && $this->GetOwnerID() == c_comdef_server::GetCurrentUserObj()->GetID())
+			if ( c_comdef_server::IsUserServiceBodyAdmin() && $this->GetOwnerID() == c_comdef_server::GetCurrentUserObj()->GetID() )
 				{
 				return true;
 				}

--- a/main_server/server/classes/c_comdef_user.class.php
+++ b/main_server/server/classes/c_comdef_user.class.php
@@ -122,7 +122,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 					$before_lang = $before_obj_clone->GetLocalLang();
 					$before_obj_clone = null;
 					}
-	
+
 				$this->DeleteFromDB_NoRecord();
 				
 				try
@@ -746,6 +746,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 			{
 			$in_user_clone->RestoreFromDB();	// The reason you do this, is to ensure that the user wasn't modified "live." It's a security precaution.
 			// Only the server admin can edit users. However, users can edit themselves.
+			// This will have to be changed to allow service body admins to edit their users
 			if ( ($in_user_clone->GetUserLevel() != _USER_LEVEL_DISABLED) && ($in_user_clone->GetUserLevel() != _USER_LEVEL_OBSERVER) && (($in_user_clone->GetID() == $this->GetID()) || c_comdef_server::IsUserServerAdmin()) )
 				{
 				$ret = true;

--- a/main_server/server/classes/c_comdef_user.class.php
+++ b/main_server/server/classes/c_comdef_user.class.php
@@ -221,8 +221,6 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 				{
 				$sql = "DELETE FROM `".c_comdef_server::GetUserTableName_obj()."` WHERE id_bigint=?";
 				c_comdef_dbsingleton::preparedExec($sql, array ( $this->GetID() ) );
-				$sql = "UPDATE `".c_comdef_server::GetUserTableName_obj()."` SET owner_id_bigint=-1 WHERE owner_id_bigint=?";
-				c_comdef_dbsingleton::preparedExec($sql, array ( $this->GetID() ) );
 				$ret = true;
 				}
 			catch ( Exception $ex )
@@ -278,6 +276,31 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 				}
 			}
 		
+		return $ret;
+	}
+
+	function ResetChildUsers()
+	{
+		$ret = false;
+
+		try
+			{
+			$sql = "UPDATE `".c_comdef_server::GetUserTableName_obj()."` SET owner_id_bigint=-1 WHERE owner_id_bigint=?";
+			c_comdef_dbsingleton::preparedExec($sql, array ( $this->GetID() ) );
+			$ret = true;
+			}
+		catch ( Exception $ex )
+			{
+			global	$_COMDEF_DEBUG;
+
+			if ( $_COMDEF_DEBUG )
+				{
+				echo "Exception Thrown in c_comdef_user::ResetChildUsers()!<br />";
+				var_dump ( $ex );
+				}
+			throw ( $ex );
+			}
+
 		return $ret;
 	}
 	

--- a/main_server/server/classes/c_comdef_user.class.php
+++ b/main_server/server/classes/c_comdef_user.class.php
@@ -221,6 +221,8 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 				{
 				$sql = "DELETE FROM `".c_comdef_server::GetUserTableName_obj()."` WHERE id_bigint=?";
 				c_comdef_dbsingleton::preparedExec($sql, array ( $this->GetID() ) );
+				$sql = "UPDATE `".c_comdef_server::GetUserTableName_obj()."` SET owner_id_bigint=-1 WHERE owner_id_bigint=?";
+				c_comdef_dbsingleton::preparedExec($sql, array ( $this->GetID() ) );
 				$ret = true;
 				}
 			catch ( Exception $ex )

--- a/main_server/server/classes/c_comdef_user.class.php
+++ b/main_server/server/classes/c_comdef_user.class.php
@@ -772,8 +772,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 		if ( $in_user_clone instanceof c_comdef_user )
 			{
 			$in_user_clone->RestoreFromDB();	// The reason you do this, is to ensure that the user wasn't modified "live." It's a security precaution.
-			// Only the server admin can edit users. However, users can edit themselves.
-			// This will have to be changed to allow service body admins to edit their users
+			// Server admins can edit users. Service body administrators can edit users they own. Any user can edit itself.
 			if ( $in_user_clone->GetUserLevel() == _USER_LEVEL_DISABLED )
 				{
 				return false;

--- a/main_server/server/classes/c_comdef_user.class.php
+++ b/main_server/server/classes/c_comdef_user.class.php
@@ -82,6 +82,9 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 	
 	/// A time date, indicating the last time the user was active. This will be useful for administration.
 	private $_last_access = null;
+
+	/// An integer containing the id of the user that owns this user.
+	private $_owner_id_bigint = -1;
 	
 	/*******************************************************************/
 	/** \brief Updates or adds this instance to the database.
@@ -152,18 +155,19 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 					array_push ( $update, $this->GetLocalName() );
 					array_push ( $update, $this->GetLocalDescription() );
 					array_push ( $update, $this->GetLocalLang() );
+					array_push ( $update, $this->GetOwnerID() );
 					
 					$sql = "INSERT INTO `".c_comdef_server::GetUserTableName_obj()."` (";
 					if ( $this->_id_bigint )
 						{
 						$sql .= "`id_bigint`,";
 						}
-					$sql .= "`user_level_tinyint`,`email_address_string`,`login_string`,`password_string`,`last_access_datetime`,`name_string`,`description_string`,`lang_enum`) VALUES (";
+					$sql .= "`user_level_tinyint`,`email_address_string`,`login_string`,`password_string`,`last_access_datetime`,`name_string`,`description_string`,`lang_enum`, `owner_id_bigint`) VALUES (";
 					if ( $this->_id_bigint )
 						{
 						$sql .= "?,";
 						}
-					$sql .= "?,?,?,?,?,?,?,?)";
+					$sql .= "?,?,?,?,?,?,?,?,?)";
 					c_comdef_dbsingleton::preparedExec($sql, $update );
 					// If this is a new user, then we'll need to fetch the ID.
 					if ( !$this->_id_bigint )
@@ -295,6 +299,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 					$this->_email_address_string = $rows[0]['email_address_string'];
 					$this->_login_string = $rows[0]['login_string'];
 					$this->_password_string = $rows[0]['password_string'];
+					$this->_owner_id_bigint = $rows[0]['owner_id_bigint'];
 					$time = explode ( " ", $rows[0]['last_access_datetime'] );
 					$t0 = explode ( "-", $time[0] );
 					$t1 = explode ( ":", $time[1] );
@@ -358,7 +363,8 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 						$in_lang_enum,				///< An enum/string, with the user's language.
 						$in_name_string,			///< A string, containing the readble name for the user.
 						$in_description_string,		///< A string, containing a description of the user.
-						$in_last_access = null		///< An epoch time, indicating the last access of this user (Optional).
+						$in_owner_id_bigint = -1,   ///< An integer containing the id of the user that owns this user.
+						$in_last_access = null	    ///< An epoch time, indicating the last access of this user (Optional).
 						)
 	{
 		// Set the four inherited values.
@@ -373,6 +379,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 		$this->_email_address_string = $in_email_address_string;
 		$this->_login_string = $in_login_string;
 		$this->_password_string = $in_password_string;
+		$this->_owner_id_bigint = $in_owner_id_bigint;
 		$this->_last_access = $in_last_access;
 	}
 	
@@ -405,7 +412,25 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 	{
 		$this->_id_bigint = $in_user_id_bigint;
 	}
-	
+
+	/*******************************************************************/
+	/** \brief Accessor - Gets the owner ID as an integer.
+	 */
+	function GetOwnerID()
+	{
+		return $this->_owner_id_bigint;
+	}
+
+	/*******************************************************************/
+	/** \brief Accessor - Sets the owner ID as an integer.
+	 */
+	function SetOwnerID(
+						$in_owner_id_bigint
+						)
+	{
+		$this->_owner_id_bigint = $in_owner_id_bigint;
+	}
+
 	/*******************************************************************/
 	/** \brief Accessor - Returns the user level as an integer.
 		
@@ -690,6 +715,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 								$this->_last_access,
 								$this->GetLocalName(),
 								$this->GetLocalDescription(),
+								$this->_owner_id_bigint,
 								$this->GetLocalLang()
 								);
 		
@@ -716,9 +742,10 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 				$_last_access,
 				$_local_name,
 				$_local_description,
+				$_owner_id_bigint,
 				$_local_lang ) = unserialize ( $serialized_string );
 				
-		return new c_comdef_user ( $in_parent, $_id_bigint, $_user_level_tinyint, $_email_address_string, $_login_string, $_password_string, $_local_lang, $_local_name, $_local_description, $_last_access );
+		return new c_comdef_user ( $in_parent, $_id_bigint, $_user_level_tinyint, $_email_address_string, $_login_string, $_password_string, $_local_lang, $_local_name, $_local_description, $_owner_id_bigint, $_last_access );
 	}
 	
 	/*******************************************************************/
@@ -747,9 +774,29 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 			$in_user_clone->RestoreFromDB();	// The reason you do this, is to ensure that the user wasn't modified "live." It's a security precaution.
 			// Only the server admin can edit users. However, users can edit themselves.
 			// This will have to be changed to allow service body admins to edit their users
-			if ( ($in_user_clone->GetUserLevel() != _USER_LEVEL_DISABLED) && ($in_user_clone->GetUserLevel() != _USER_LEVEL_OBSERVER) && (($in_user_clone->GetID() == $this->GetID()) || c_comdef_server::IsUserServerAdmin()) )
+			if ( $in_user_clone->GetUserLevel() == _USER_LEVEL_DISABLED )
 				{
-				$ret = true;
+				return false;
+				}
+
+			if ( $in_user_clone->GetUserLevel() == _USER_LEVEL_OBSERVER )
+				{
+				return false;
+				}
+
+			if ( $in_user_clone->GetID() == $this->GetID() )
+				{
+				return true;
+				}
+
+			if ( c_comdef_server::IsUserServerAdmin() )
+				{
+				return true;
+				}
+
+			if (c_comdef_server::IsUserServiceBodyAdmin() && $this->GetOwnerID() == c_comdef_server::GetCurrentUserObj()->GetID())
+				{
+				return true;
 				}
 			
 			$in_user_clone = null;


### PR DESCRIPTION
1. Adds owner_id_bigint column to users table.
2. Provides a way for server admins to assign user ownership through user admin UI.
3. Allows service body admins to edit users they own (editing only, not adding or deleting).

NOTE: Please don't merge this until we finish testing and any necessary documentation changes.