### PR TITLE
Fix array2json to handle integers and booleans properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ For instructions on installing the root server, see [the page on installing a ne
 CHANGELIST
 ----------
 
+***Version 2.11.1* ** *- TBD*
+
+- Fixed an issue where the user would erroneously receive a warning when switching between edited users and service bodies.
+
 ***Version 2.11.0* ** *- September 28, 2018*
 
 - Added the ability to allow Service Body Administrators to edit their users.

--- a/main_server/client_interface/serverInfo.xml
+++ b/main_server/client_interface/serverInfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <bmltInfo>
 	<serverVersion>
-		<readableString>2.11.0</readableString>
+		<readableString>2.11.1</readableString>
 	</serverVersion>
 </bmltInfo>

--- a/main_server/server/shared/Array2Json.php
+++ b/main_server/server/shared/Array2Json.php
@@ -76,7 +76,18 @@ function array2json (
                 //Custom handling for multiple data types
                 if ( isset ($value) )
                     {
-                    $str .= '"' . trim ( json_encode ( str_replace ( '"', '&quot;', $value ) ), '"' ) . '"'; //All other things
+                    if ( is_integer( $value ) )
+                        {
+                        $str .= $value;
+                        }
+                    elseif ( is_bool ( $value ) )
+                        {
+                        $str .= $value ? 'true': 'false';
+                        }
+                    else
+                        {
+                        $str .= '"' . trim ( json_encode ( str_replace ( '"', '&quot;', $value ) ), '"' ) . '"'; //All other things
+                        }
                     }
                 else
                     {


### PR DESCRIPTION
This fixes an issue where the user is warned that they will lose changes when switching between users and service bodies, even after they have properly saved their changes. The problem was that the json returned by the server was not properly encoded, so that comparisons between the object in browser memory and the returned saved in the javascript callback handlers were failing.

I validated that saving Users, Service Bodies, and Formats now works properly.