### PR TITLE
Bugfix/bad prompt switch between meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ CHANGELIST
 
 - Fixed an issue where the user would erroneously receive a warning when switching between edited users and service bodies.
 - Fixed an issue with cutting/pasting into text fields in the administration UI.
+- Fixed an issue with editing meetings where the "Save" button would be enabled even if no changes had been made.
 
 ***Version 2.11.0* ** *- September 28, 2018*
 

--- a/main_server/client_interface/csv/search_results_csv.php
+++ b/main_server/client_interface/csv/search_results_csv.php
@@ -562,6 +562,7 @@ function DisplaySearchResultsCSV ( $in_http_vars,	/**< The various HTTP GET and 
                         
                         if ( isset($format_shared_id_list) && is_array($format_shared_id_list) && count($format_shared_id_list) )
                             {
+                            sort($format_shared_id_list);
                             $line['format_shared_id_list'] = implode(',', $format_shared_id_list);
                             }
                             

--- a/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -1298,6 +1298,10 @@ class c_comdef_admin_ajax_handler
                     { // Strip first double quote
                     $row = substr($row, 1, strlen($row) - 1);
                     }
+                if (substr($row, strlen($row) - 1, 1) == ',')
+                    { // Strip last comma, just in case
+                        $row = substr($row, 0, strlen($row) - 1);
+                    }
                 if (substr($row, strlen($row) - 1, 1) == '"')
                     { // Strip last double quote
                     $row = substr($row, 0, strlen($row) - 1);

--- a/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -1293,7 +1293,16 @@ class c_comdef_admin_ajax_handler
                 {
                 $line = null;
                 $index = 0;
-                $row = explode ( '","', trim ( $row, '",' ) );
+                $row = trim($row);
+                if (substr($row, 0, 1) == '"')
+                    { // Strip first double quote
+                    $row = substr($row, 1, strlen($row) - 1);
+                    }
+                if (substr($row, strlen($row) - 1, 1) == '"')
+                    { // Strip last double quote
+                    $row = substr($row, 0, strlen($row) - 1);
+                    }
+                $row = explode ( '","', $row );
                 foreach ( $row as $column )
                     {
                     if ( isset ( $column ) )

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -617,6 +617,7 @@ function BMLT_Server_Admin ()
             ret.published = '0';
             ret.service_body_bigint = g_service_bodies_array[0][0].toString();
             ret.formats = '';
+            ret.format_shared_id_list = '';
             };
         
         ret.zoom = g_default_zoom;


### PR DESCRIPTION
Because TranslateToJSON splits on `","`, double quotes on the beginning and end of each row are still in the string. It attempted to solve this by stripping `",`, but this had the side effect of stripping empty values such as `,""`.

Fix by just removing the first and last double quote from each row, if they exist. Also strip a trailing comma. The trailing comma should never occur, but the old code accounted for it, so we account for it here too just to be safe.