### PR TITLE
Allow specification of state/province select menu items, first pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ CHANGELIST
 ----------
 
 ***Version 2.11.2* ** *- TBD*
+- Added the ability to display a fixed set of states/provinces when editing meetings in a dropdown menu rather than a freeform text field with a new `$meeting_states_and_provinces` setting.
 - Fixed a UX issue where the NAWS Export link was in close proximity to the Delete Service Body button, resulting in accidental deletion of service bodies.
 - Fixed an issue where the My Account save button would be incorrectly enabled/disabled (again).
 

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -1778,7 +1778,18 @@ class c_comdef_admin_main_console
                 $ret .= '</div>';
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_state_label'] ).'</span>';
-                    $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_state_text_input" type="text" value="'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_state_prompt'] ).'" /></span>';
+                    $ret .= '<span class="bmlt_admin_value_left">';
+                        if ( is_array( $this->my_localized_strings['meeting_states_and_provinces'] ) && count( $this->my_localized_strings['meeting_states_and_provinces'] ) ) {
+                            $ret .= '<select id="bmlt_admin_single_meeting_editor_template_meeting_state_select_input" class="bmlt_admin_single_meeting_editor_template_meeting_state_select_input">';
+                                $ret .= '<option value=""></option>';
+                                foreach ( $this->my_localized_strings['meeting_states_and_provinces'] as $value ) {
+                                    $ret .= '<option value="'. htmlspecialchars( $value ) .'">'. htmlspecialchars( $value ) .'</option>';
+                                }
+                            $ret .= '</select>';
+                        } else {
+                            $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_state_text_input" type="text" value="'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_state_prompt'] ).'" /></span>';
+                        }
+                    $ret .= '</span>';
                     $ret .= '<div class="clear_both"></div>';
                 $ret .= '</div>';
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -1779,15 +1779,19 @@ class c_comdef_admin_main_console
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_state_label'] ).'</span>';
                     $ret .= '<span class="bmlt_admin_value_left">';
-                        if ( is_array( $this->my_localized_strings['meeting_states_and_provinces'] ) && count( $this->my_localized_strings['meeting_states_and_provinces'] ) ) {
-                            $ret .= '<select id="bmlt_admin_single_meeting_editor_template_meeting_state_select_input" class="bmlt_admin_single_meeting_editor_template_meeting_state_select_input">';
-                                $ret .= '<option value=""></option>';
-                                foreach ( $this->my_localized_strings['meeting_states_and_provinces'] as $value ) {
-                                    $ret .= '<option value="'. htmlspecialchars( $value ) .'">'. htmlspecialchars( $value ) .'</option>';
-                                }
-                            $ret .= '</select>';
-                        } else {
-                            $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_state_text_input" type="text" value="'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_state_prompt'] ).'" /></span>';
+                    if ( is_array( $this->my_localized_strings['meeting_states_and_provinces'] ) && count( $this->my_localized_strings['meeting_states_and_provinces'] ) )
+                        {
+                        $ret .= '<select id="bmlt_admin_single_meeting_editor_template_meeting_state_select_input" class="bmlt_admin_single_meeting_editor_template_meeting_state_select_input">';
+                        $ret .= '<option value=""></option>';
+                        foreach ( $this->my_localized_strings['meeting_states_and_provinces'] as $value )
+                            {
+                            $ret .= '<option value="'. htmlspecialchars( $value ) .'">'. htmlspecialchars( $value ) .'</option>';
+                            }
+                        $ret .= '</select>';
+                        }
+                    else
+                        {
+                        $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_state_text_input" type="text" value="'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_state_prompt'] ).'" /></span>';
                         }
                     $ret .= '</span>';
                     $ret .= '<div class="clear_both"></div>';

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -2627,7 +2627,7 @@ function BMLT_Server_Admin ()
             var street_text = meeting_street_text_item.value;
             var borough_text = meeting_borough_text_item.value;
             var city_text = meeting_city_text_item.value;
-            var state_text = meeting_state_text_item !== null ? meeting_state_text_item.value : meeting_state_select_item.options[meeting_state_select_item.selectedIndex].value;
+            var state_text = meeting_state_text_item ? meeting_state_text_item.value : meeting_state_select_item.options[meeting_state_select_item.selectedIndex].value;
             var zip_text = meeting_zip_text_item.value;
             var nation_text = meeting_nation_text_item.value;
 
@@ -2674,7 +2674,7 @@ function BMLT_Server_Admin ()
         var street_text = meeting_street_text_item.value;
         var borough_text = meeting_borough_text_item.value;
         var city_text = meeting_city_text_item.value;
-        var state_text = meeting_state_text_item.value !== null ? meeting_state_text_item.value : meeting_state_select_item.options[meeting_state_select_item.selectedIndex].value;
+        var state_text = meeting_state_text_item ? meeting_state_text_item.value : meeting_state_select_item.options[meeting_state_select_item.selectedIndex].value;
         var zip_text = meeting_zip_text_item.value;
         var nation_text = meeting_nation_text_item.value;
         
@@ -2706,7 +2706,7 @@ function BMLT_Server_Admin ()
         var street_text = (meeting_street_text_item.value != meeting_street_text_item.defaultValue) ? meeting_street_text_item.value : '';
         var borough_text = (meeting_borough_text_item.value != meeting_borough_text_item.defaultValue) ? meeting_borough_text_item.value : '';
         var city_text = (meeting_city_text_item.value != meeting_city_text_item.defaultValue) ? meeting_city_text_item.value : '';
-        var state_text = meeting_state_text_item !== null ? ((meeting_state_text_item.value != meeting_state_text_item.defaultValue) ? meeting_state_text_item.value : '') : meeting_state_select_item.options[meeting_state_select_item.selectedIndex].value;
+        var state_text = meeting_state_text_item ? ((meeting_state_text_item.value != meeting_state_text_item.defaultValue) ? meeting_state_text_item.value : '') : meeting_state_select_item.options[meeting_state_select_item.selectedIndex].value;
         var zip_text = (meeting_zip_text_item.value != meeting_zip_text_item.defaultValue) ? meeting_zip_text_item.value : '';
         var nation_text = (meeting_nation_text_item.value != meeting_nation_text_item.defaultValue) ? meeting_nation_text_item.value : '';
         

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -1789,7 +1789,6 @@ function BMLT_Server_Admin ()
             var meeting_city_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_city_text_input';
             var meeting_county_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_county_text_input';
             var meeting_state_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_text_input';
-            var meeting_state_select_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_select_input';
             var meeting_zip_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_zip_text_input';
             var meeting_nation_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_nation_text_input';
             var meeting_longitude_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_longitude_text_input';
@@ -1823,9 +1822,10 @@ function BMLT_Server_Admin ()
                 this.handleTextInputLoad(document.getElementById(meeting_latitude_text_item_id), 0, true);
 
                 var meeting_state_text_input = document.getElementById(meeting_state_text_item_id);
-                if (meeting_state_text_input !== null) {
+                if (meeting_state_text_input !== null)
+                    {
                     this.handleTextInputLoad(meeting_state_text_input);
-                }
+                    }
                 
                 var map_disclosure_a = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_map_disclosure_a' );
                 map_disclosure_a.href = 'javascript:admin_handler_object.toggleMeetingMapDisclosure(' + in_meeting_id + ')';
@@ -2021,7 +2021,8 @@ function BMLT_Server_Admin ()
         };
 
 
-        if (meeting_state_text_item !== null) {
+        if (meeting_state_text_item !== null)
+            {
             meeting_state_text_item.value = htmlspecialchars_decode(meeting_object.location_province ? meeting_object.location_province : meeting_state_text_item.value);
             this.setTextItemClass(meeting_state_text_item);
             meeting_state_text_item.onkeyup = function () {admin_handler_object.setItemValue(this, meeting_id, 'location_province')};
@@ -2039,19 +2040,22 @@ function BMLT_Server_Admin ()
                     admin_handler_object.setItemValue(input, meeting_id, 'location_province');
                 }, 0);
             };
-        } else {
-            if (meeting_object.location_province) {
-                for (var i = 0; i <= meeting_state_select_item.options.length; i++) {
+            }
+        else
+            {
+            if ( meeting_object.location_province )
+                {
+                for ( var i = 0; i <= meeting_state_select_item.options.length; i++ )
+                    {
                     var option = meeting_state_select_item.options[i];
-                    if (option.value == meeting_object.location_province) {
+                    if ( option.value === meeting_object.location_province )
+                        {
                         meeting_state_select_item.selectedIndex = i;
                         break;
+                        }
                     }
                 }
-            }
-            meeting_state_select_item.onchange = function() {
-                admin_handler_object.reactToMeetingStateSelect(meeting_id);
-            }
+            meeting_state_select_item.onchange = function() {admin_handler_object.reactToMeetingStateSelect( meeting_id );}
         }
 
         

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -89,7 +89,7 @@ function BMLT_Server_Admin ()
             this.m_warn_user_to_refresh = false;
             };
     };
-    
+
     // #mark - 
     // #mark Text Item Handlers
     // #mark -
@@ -1789,6 +1789,7 @@ function BMLT_Server_Admin ()
             var meeting_city_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_city_text_input';
             var meeting_county_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_county_text_input';
             var meeting_state_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_text_input';
+            var meeting_state_select_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_select_input';
             var meeting_zip_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_zip_text_input';
             var meeting_nation_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_nation_text_input';
             var meeting_longitude_text_item_id = 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_longitude_text_input';
@@ -1816,11 +1817,15 @@ function BMLT_Server_Admin ()
                 this.handleTextInputLoad(document.getElementById(meeting_borough_text_item_id));
                 this.handleTextInputLoad(document.getElementById(meeting_city_text_item_id));
                 this.handleTextInputLoad(document.getElementById(meeting_county_text_item_id));
-                this.handleTextInputLoad(document.getElementById(meeting_state_text_item_id));
                 this.handleTextInputLoad(document.getElementById(meeting_zip_text_item_id), null, true);
                 this.handleTextInputLoad(document.getElementById(meeting_nation_text_item_id), null, true);
                 this.handleTextInputLoad(document.getElementById(meeting_longitude_text_item_id), 0, true);
                 this.handleTextInputLoad(document.getElementById(meeting_latitude_text_item_id), 0, true);
+
+                var meeting_state_text_input = document.getElementById(meeting_state_text_item_id);
+                if (meeting_state_text_input !== null) {
+                    this.handleTextInputLoad(meeting_state_text_input);
+                }
                 
                 var map_disclosure_a = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_map_disclosure_a' );
                 map_disclosure_a.href = 'javascript:admin_handler_object.toggleMeetingMapDisclosure(' + in_meeting_id + ')';
@@ -1875,6 +1880,7 @@ function BMLT_Server_Admin ()
         var meeting_city_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + meeting_id + '_meeting_city_text_input' );
         var meeting_county_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + meeting_id + '_meeting_county_text_input' );
         var meeting_state_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + meeting_id + '_meeting_state_text_input' );
+        var meeting_state_select_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + meeting_id + '_meeting_state_select_input' );
         var meeting_zip_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + meeting_id + '_meeting_zip_text_input' );
         var meeting_nation_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + meeting_id + '_meeting_nation_text_input' );
         var meeting_longitude_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + meeting_id + '_meeting_longitude_text_input' );
@@ -2014,20 +2020,39 @@ function BMLT_Server_Admin ()
             setTimeout(function() { admin_handler_object.setItemValue(input, meeting_id, 'location_sub_province'); }, 0);
         };
 
-        
-        meeting_state_text_item.value = htmlspecialchars_decode ( meeting_object.location_province ? meeting_object.location_province : meeting_state_text_item.value );
-        this.setTextItemClass ( meeting_state_text_item );
-        meeting_state_text_item.onkeyup = function(){admin_handler_object.setItemValue(this, meeting_id, 'location_province')};
-        meeting_state_text_item.onfocus = function(){admin_handler_object.handleTextInputFocus(this)};
-        meeting_state_text_item.onblur = function(){admin_handler_object.handleTextInputBlur(this)};
-        meeting_state_text_item.onpaste = function() {
-            var input = this;
-            setTimeout(function() { admin_handler_object.setItemValue(input, meeting_id, 'location_province'); }, 0);
-        };
-        meeting_state_text_item.oncut = function() {
-            var input = this;
-            setTimeout(function() { admin_handler_object.setItemValue(input, meeting_id, 'location_province'); }, 0);
-        };
+
+        if (meeting_state_text_item !== null) {
+            meeting_state_text_item.value = htmlspecialchars_decode(meeting_object.location_province ? meeting_object.location_province : meeting_state_text_item.value);
+            this.setTextItemClass(meeting_state_text_item);
+            meeting_state_text_item.onkeyup = function () {admin_handler_object.setItemValue(this, meeting_id, 'location_province')};
+            meeting_state_text_item.onfocus = function () {admin_handler_object.handleTextInputFocus(this)};
+            meeting_state_text_item.onblur = function () {admin_handler_object.handleTextInputBlur(this)};
+            meeting_state_text_item.onpaste = function () {
+                var input = this;
+                setTimeout(function () {
+                    admin_handler_object.setItemValue(input, meeting_id, 'location_province');
+                }, 0);
+            };
+            meeting_state_text_item.oncut = function () {
+                var input = this;
+                setTimeout(function () {
+                    admin_handler_object.setItemValue(input, meeting_id, 'location_province');
+                }, 0);
+            };
+        } else {
+            if (meeting_object.location_province) {
+                for (var i = 0; i <= meeting_state_select_item.options.length; i++) {
+                    var option = meeting_state_select_item.options[i];
+                    if (option.value == meeting_object.location_province) {
+                        meeting_state_select_item.selectedIndex = i;
+                        break;
+                    }
+                }
+            }
+            meeting_state_select_item.onchange = function() {
+                admin_handler_object.reactToMeetingStateSelect(meeting_id);
+            }
+        }
 
         
         meeting_zip_text_item.value = htmlspecialchars_decode ( meeting_object.location_postal_code_1 ? meeting_object.location_postal_code_1 : meeting_zip_text_item.value );
@@ -2520,7 +2545,16 @@ function BMLT_Server_Admin ()
         the_meeting_object.duration_time = timeval;
         this.validateMeetingEditorButton ( in_meeting_id );
     };
-    
+
+    this.reactToMeetingStateSelect = function(in_meeting_id) {
+        var meeting_state_select_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_select_input' );
+        var editor_object = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_div' );
+        var the_meeting_object = editor_object.meeting_object;
+        the_meeting_object.location_province = meeting_state_select_item.options[meeting_state_select_item.selectedIndex].value;
+        this.handleNewAddressInfo( in_meeting_id );
+        this.validateMeetingEditorButton ( in_meeting_id );
+    };
+
     /************************************************************************************//**
     *   \brief 
     ****************************************************************************************/
@@ -2580,15 +2614,16 @@ function BMLT_Server_Admin ()
         var meeting_borough_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_borough_text_input' );
         var meeting_city_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_city_text_input' );
         var meeting_state_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_text_input' );
+        var meeting_state_select_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_select_input' );
         var meeting_zip_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_zip_text_input' );
         var meeting_nation_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_nation_text_input' );
 
-        if ( meeting_street_text_item && meeting_borough_text_item && meeting_city_text_item && meeting_state_text_item && meeting_zip_text_item && meeting_nation_text_item )
+        if ( meeting_street_text_item && meeting_borough_text_item && meeting_city_text_item && ( meeting_state_text_item || meeting_state_select_item ) && meeting_zip_text_item && meeting_nation_text_item )
             {
             var street_text = meeting_street_text_item.value;
             var borough_text = meeting_borough_text_item.value;
             var city_text = meeting_city_text_item.value;
-            var state_text = meeting_state_text_item.value;
+            var state_text = meeting_state_text_item !== null ? meeting_state_text_item.value : meeting_state_select_item.options[meeting_state_select_item.selectedIndex].value;
             var zip_text = meeting_zip_text_item.value;
             var nation_text = meeting_nation_text_item.value;
 
@@ -2628,13 +2663,14 @@ function BMLT_Server_Admin ()
         var meeting_borough_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_borough_text_input' );
         var meeting_city_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_city_text_input' );
         var meeting_state_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_text_input' );
+        var meeting_state_select_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_select_input' );
         var meeting_zip_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_zip_text_input' );
         var meeting_nation_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_nation_text_input' );
 
         var street_text = meeting_street_text_item.value;
         var borough_text = meeting_borough_text_item.value;
         var city_text = meeting_city_text_item.value;
-        var state_text = meeting_state_text_item.value;
+        var state_text = meeting_state_text_item.value !== null ? meeting_state_text_item.value : meeting_state_select_item.options[meeting_state_select_item.selectedIndex].value;
         var zip_text = meeting_zip_text_item.value;
         var nation_text = meeting_nation_text_item.value;
         
@@ -2659,13 +2695,14 @@ function BMLT_Server_Admin ()
         var meeting_borough_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_borough_text_input' );
         var meeting_city_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_city_text_input' );
         var meeting_state_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_text_input' );
+        var meeting_state_select_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_state_select_input' );
         var meeting_zip_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_zip_text_input' );
         var meeting_nation_text_item = document.getElementById ( 'bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_nation_text_input' );
 
         var street_text = (meeting_street_text_item.value != meeting_street_text_item.defaultValue) ? meeting_street_text_item.value : '';
         var borough_text = (meeting_borough_text_item.value != meeting_borough_text_item.defaultValue) ? meeting_borough_text_item.value : '';
         var city_text = (meeting_city_text_item.value != meeting_city_text_item.defaultValue) ? meeting_city_text_item.value : '';
-        var state_text = (meeting_state_text_item.value != meeting_state_text_item.defaultValue) ? meeting_state_text_item.value : '';
+        var state_text = meeting_state_text_item !== null ? ((meeting_state_text_item.value != meeting_state_text_item.defaultValue) ? meeting_state_text_item.value : '') : meeting_state_select_item.options[meeting_state_select_item.selectedIndex].value;
         var zip_text = (meeting_zip_text_item.value != meeting_zip_text_item.defaultValue) ? meeting_zip_text_item.value : '';
         var nation_text = (meeting_nation_text_item.value != meeting_nation_text_item.defaultValue) ? meeting_nation_text_item.value : '';
         

--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -2893,7 +2893,8 @@ class c_comdef_server
                 {
                 c_comdef_server::$server_local_strings['include_service_body_email_in_semantic'] = $g_include_service_body_email_in_semantic;
                 }
-                
+
+            c_comdef_server::$server_local_strings['meeting_states_and_provinces'] = isset ( $meeting_states_and_provinces ) ? $meeting_states_and_provinces : array();
             c_comdef_server::$server_local_strings['google_api_key'] = isset ( $gkey ) ? $gkey : '';
             c_comdef_server::$server_local_strings['region_bias'] = isset ( $region_bias ) ? $region_bias : 'us';
             c_comdef_server::$server_local_strings['default_duration_time'] = isset ( $default_duration_time ) ? $default_duration_time : '01:00:00';


### PR DESCRIPTION
If `$meeting_states_and_provinces` is defined in `auto-config.inc.php`, is an array, and is non-empty, a select box is shown instead of the normal text box.

Addresses https://github.com/LittleGreenViper/BMLT-Root-Server/issues/26.

In the future, we may modify the wizard to set this in `auto-config.inc.php` if the users chooses to do so. For now, it must be manually set.